### PR TITLE
Repository optimization using automappers ProjectTo

### DIFF
--- a/PokemonAPI/PokemonAPI.BusinessLayer/Implementations/DomainServices/AuthenticationService.cs
+++ b/PokemonAPI/PokemonAPI.BusinessLayer/Implementations/DomainServices/AuthenticationService.cs
@@ -1,22 +1,22 @@
-﻿using System;
-using System.Security.Authentication;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using PokemonAPI.BusinessLayer.Interfaces;
 using PokemonAPI.DomainLayer.Entities;
 using PokemonAPI.PersistenceLayer.Interfaces;
+using System;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PokemonAPI.BusinessLayer.Implementations.DomainServices
 {
     internal class AuthenticationService : IAuthenticationService
     {
-        private readonly IRepository<Admin> _repository;
+        private readonly IRepository<Admin, Admin> _repository;
         private readonly IJwtGenerator _jwtGenerator;
         private readonly IPasswordHasher _passwordHasher;
         private readonly ILogger<AuthenticationService> _logger;
 
-        public AuthenticationService(IRepository<Admin> repository, IJwtGenerator jwtGenerator, IPasswordHasher passwordHasher, ILogger<AuthenticationService> logger)
+        public AuthenticationService(IRepository<Admin, Admin> repository, IJwtGenerator jwtGenerator, IPasswordHasher passwordHasher, ILogger<AuthenticationService> logger)
         {
             _repository = repository;
             _jwtGenerator = jwtGenerator;
@@ -29,8 +29,7 @@ namespace PokemonAPI.BusinessLayer.Implementations.DomainServices
             try
             {
                 var admin = await _repository.Get(
-                    filter: user => user.Username == username && user.PasswordHash == _passwordHasher.GetPasswordHash(password),
-                    cancellationToken: cancellationToken);
+                    filter: user => user.Username == username && user.PasswordHash == _passwordHasher.GetPasswordHash(password));
 
                 if (admin == null)
                     throw new AuthenticationException();

--- a/PokemonAPI/PokemonAPI.BusinessLayer/Implementations/DomainServices/CatchService.cs
+++ b/PokemonAPI/PokemonAPI.BusinessLayer/Implementations/DomainServices/CatchService.cs
@@ -1,8 +1,6 @@
 ﻿using AutoMapper;
 using PokemonAPI.BusinessLayer.Exceptions;
 using PokemonAPI.BusinessLayer.Interfaces;
-using PokemonAPI.DomainLayer.Entities;
-using PokemonAPI.PersistenceLayer.Interfaces;
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -15,23 +13,20 @@ namespace PokemonAPI.BusinessLayer.Implementations.DomainServices
     {
         private readonly IPokemonService _pokemonService;
         private readonly IMapper _mapper;
-        private readonly IRepository<Pokemon> _pokeRepository;
         private readonly IChanceGenerator _chanceGenerator;
 
-        public CatchService(IPokemonService pokemonService, IMapper mapper, IRepository<Pokemon> pokeRepository, IChanceGenerator chanceGenerator)
+        public CatchService(IPokemonService pokemonService, IMapper mapper, IChanceGenerator chanceGenerator)
         {
             _pokemonService = pokemonService;
             _mapper = mapper;
-            _pokeRepository = pokeRepository;
             _chanceGenerator = chanceGenerator;
         }
 
         public async Task CatchPokemon(Guid pokemonId, Guid trainerId, CancellationToken cancellationToken = default)
         {
             var pokemon = await _pokemonService.Get(pokemonId, cancellationToken);
-            var pokemonEntity = _mapper.Map<Pokemon>(pokemon);
 
-            if (pokemonEntity.Trainer != null)
+            if (pokemon.Trainer != null)
                 throw new CatchPokemonException("Pokemon already has a trainer");
 
             if (_chanceGenerator.getChance(2) != 0)
@@ -39,9 +34,9 @@ namespace PokemonAPI.BusinessLayer.Implementations.DomainServices
                 throw new CatchPokemonException("Unfortunately pokemon dodged your pokeball");
             }
 
-            pokemonEntity.TrainerId = trainerId;
+            pokemon.TrainerId = trainerId;
 
-            await _pokeRepository.Update(pokemonEntity, cancellationToken);
+            await _pokemonService.Update(pokemon, cancellationToken);
         }
     }
 }

--- a/PokemonAPI/PokemonAPI.BusinessLayer/Implementations/DomainServices/TrainerService.cs
+++ b/PokemonAPI/PokemonAPI.BusinessLayer/Implementations/DomainServices/TrainerService.cs
@@ -9,7 +9,6 @@ using PokemonAPI.PersistenceLayer.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,12 +18,12 @@ namespace PokemonAPI.BusinessLayer.Implementations.DomainServices
 {
     internal class TrainerService : ITrainerService
     {
-        private readonly IRepository<Trainer> _repository;
+        private readonly IRepository<Trainer, TrainerDTO> _repository;
         private readonly IMapper _mapper;
         private readonly TrainerValidator _validator = new TrainerValidator();
         private readonly ILogger<TrainerService> _logger;
 
-        public TrainerService(IRepository<Trainer> repository, IMapper mapper, ILogger<TrainerService> logger)
+        public TrainerService(IRepository<Trainer, TrainerDTO> repository, IMapper mapper, ILogger<TrainerService> logger)
         {
             _repository = repository;
             _mapper = mapper;
@@ -74,19 +73,18 @@ namespace PokemonAPI.BusinessLayer.Implementations.DomainServices
                 throw new NotFoundException(id);
 
             _logger.LogInformation($"Get request for trainer: {id} succesfull");
-            return _mapper.Map<TrainerDTO>(trainer);
+            return trainer;
         }
 
         public async Task<IEnumerable<TrainerDTO>> GetAll(CancellationToken cancellationToken = default)
         {
             var trainers = await _repository.GetAll(
                 include: source => source
-                    .Include(t => t.CaughtPokemons),
-                cancellationToken: cancellationToken
+                    .Include(t => t.CaughtPokemons)
             );
 
             _logger.LogInformation("Get all trainers request succesfull");
-            return _mapper.Map<IEnumerable<TrainerDTO>>(trainers);
+            return trainers;
         }
 
         public async Task Update(TrainerDTO trainer, CancellationToken cancellationToken = default)

--- a/PokemonAPI/PokemonAPI.BusinessLayer/PokemonAPI.BusinessLayer.csproj
+++ b/PokemonAPI/PokemonAPI.BusinessLayer/PokemonAPI.BusinessLayer.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />

--- a/PokemonAPI/PokemonAPI.PersistenceLayer/Interfaces/IRepository.cs
+++ b/PokemonAPI/PokemonAPI.PersistenceLayer/Interfaces/IRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore.Query;
 using PokemonAPI.DomainLayer.Entities;
+using PokemonAPI.DomainLayer.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,7 +10,9 @@ using System.Threading.Tasks;
 
 namespace PokemonAPI.PersistenceLayer.Interfaces
 {
-    public interface IRepository<TEntity> where TEntity : EntityBase
+    public interface IRepository<TEntity, TProjection>
+       where TEntity : EntityBase, IEntity
+       where TProjection : class
     {
         /// <summary>
         /// Gets all entities
@@ -19,14 +22,14 @@ namespace PokemonAPI.PersistenceLayer.Interfaces
         /// <param name="include">Include statement</param>
         /// <param name="disableTracking">Disables tracking</param>
         /// <param name="cancellationToken"></param>
-        Task<IEnumerable<TEntity>> GetAll(
+        Task<IEnumerable<TProjection>> GetAll(
             Expression<Func<TEntity, bool>> filter = null,
             Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null,
             Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> include = null,
             bool disableTracking = true,
             CancellationToken cancellationToken = default);
 
-        /// <summary>
+        /// <summary>g
         /// Gets single entity by ID
         /// </summary>
         /// <param name="filter">Filter predicate</param>
@@ -35,12 +38,11 @@ namespace PokemonAPI.PersistenceLayer.Interfaces
         /// <param name="disableTracking">Disables tracking</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<TEntity> Get(Expression<Func<TEntity, bool>> filter = null,
+        Task<TProjection> Get(Expression<Func<TEntity, bool>> filter = null,
             Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null,
             Func<IQueryable<TEntity>, IIncludableQueryable<TEntity, object>> include = null,
             bool disableTracking = true,
             CancellationToken cancellationToken = default);
-
 
         /// <summary>
         /// Inserts single entity

--- a/PokemonAPI/PokemonAPI.PersistenceLayer/PokemonAPI.PersistenceLayer.csproj
+++ b/PokemonAPI/PokemonAPI.PersistenceLayer/PokemonAPI.PersistenceLayer.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\PokemonAPI.DomainLayer\PokemonAPI.DomainLayer.csproj" />
   </ItemGroup>
 

--- a/PokemonAPI/PokemonAPI.PersistenceLayer/ServiceCollectionExtensions.cs
+++ b/PokemonAPI/PokemonAPI.PersistenceLayer/ServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ namespace PokemonAPI.PersistenceLayer
             services.AddTransient<ApplicationDbContext>();
 
             // add repositories to DI
-            services.AddTransient(typeof(IRepository<>), typeof(Repository<>));
+            services.AddTransient(typeof(IRepository<,>), typeof(Repository<,>));
             //services.AddTransient<IPokemonRepository, PokemonRepository>();
         }
 

--- a/PokemonAPI/Tests/Tests.BusinessLayer/TrainerServiceTests.cs
+++ b/PokemonAPI/Tests/Tests.BusinessLayer/TrainerServiceTests.cs
@@ -113,7 +113,7 @@ namespace Tests.BusinessLayer
             var inputGuidToAssert = Guid.Empty;
 
             //arrange 
-            var repository = new Mock<IRepository<Trainer>>();
+            var repository = new Mock<IRepository<Trainer, TrainerDTO>>();
             var insertSetup = repository.Setup(x =>
                 x.Delete(
                     It.IsAny<Guid>(),


### PR DESCRIPTION
Created little optimization on our repository using automapper queryable extensions for projecting

What will this do exactly ?
Remember how we talked about IQueryable still not being executed on database right?
Well till now we were doing (after all ordering, sorting, paging and what not)

`entities.ToListAsync()`

This would basically do
`SELECT * FROM pokemons`

A little optimization would be if we didn't have to do mapping in memory but on database with say..
`SELECT Name, Description FROM pokemon`

And just return that projection...

With these queryable extensions (ProjectTo) coming from automapper. Automapper reads it's configuration. Finds approprate mapping and in synergy with EF Core creates projection query. Thus allowing us to do this on database. Also it eliminates need to do extra step with mapping in our services..

However I didn't exactly solve overloads for when we don't want to have DTO projection in our repository 
(Look at IRepository<Admin, Admin> (dirty trick) but it can be written better)

 